### PR TITLE
Adding concurrency to consistency check feature

### DIFF
--- a/ops/consistency_test.go
+++ b/ops/consistency_test.go
@@ -78,7 +78,7 @@ func TestRecursiveConsistency(t *testing.T) {
 		assert.True(t, Exists(filepath.Join(baseRestoreDir, relLocation, Current)))
 	}
 
-	flag, err := DoRecursiveConsistency(baseDataDir, baseRestoreDir)
+	flag, err := DoRecursiveConsistency(baseDataDir, baseRestoreDir, 5)
 	assert.NoError(t, err)
 	assert.Equal(t, flag, 0, "flag should be equal to 0")
 }


### PR DESCRIPTION
@ashwanthkumar : please review. 

Requested by Anitha as doing a consistency check of close to more than 100 shards is taking more than 2 hours to do a full check without parallel threads. 
