### PR TITLE
rocks consistency with paranoid flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,18 @@ Flags:
 
 ### Consistency
 ```
-Checks for the consistency between rocks store and it's corresponding restore
+$ rocks consistency --help
+Checks for the consistency between rocks store and it's corresponding restore using row counts
 
 Usage:
   rocks consistency [flags]
 
 Flags:
-      --src string    Rocks store location
-      --dest string   Restore location for Rocks store
-      --recursive     Trying to check consistency between rocks store and and it's restore
+      --paranoid             Do paranoid checks on the DB
+      --recursive            Recursively check for row counts across dbs
+      --restore-dir string   Restore location for Rocks store
+      --src-dir string       Rocks store location
+      --threads int          Number of threads to do backup (default 8)
 ```
 
 ## License

--- a/cmd/consistency/consistency.go
+++ b/cmd/consistency/consistency.go
@@ -55,18 +55,18 @@ func (result *Result) IsConsistent() bool {
 
 var consistency = &cobra.Command{
 	Use:   "consistency",
-	Short: "Checks for consistency between rocks store and it's corresponding restore",
-	Long:  "Checks for the consistency between rocks store and it's corresponding restore",
+	Short: "Checks for the consistency between rocks store and it's corresponding restore using row counts",
+	Long:  "Checks for the consistency between rocks store and it's corresponding restore using row counts",
 	Run:   cmd.AttachHandler(checkConsistency),
 }
 
 func checkConsistency(args []string) (err error) {
 	if source == "" {
-		return fmt.Errorf("--src was not set")
+		return fmt.Errorf("--src-dir was not set")
 	}
 
 	if restoredLoc == "" {
-		return fmt.Errorf("--dest was not set")
+		return fmt.Errorf("--restore-dir was not set")
 	}
 
 	if recursive {
@@ -157,8 +157,8 @@ func DoConsistency(source, restore string, paranoid bool) Result {
 func init() {
 	cmd.Rocks.AddCommand(consistency)
 
-	consistency.PersistentFlags().StringVar(&source, "src", "", "Rocks store location")
-	consistency.PersistentFlags().StringVar(&restoredLoc, "dest", "", "Restore location for Rocks store")
+	consistency.PersistentFlags().StringVar(&source, "src-dir", "", "Original data location")
+	consistency.PersistentFlags().StringVar(&restoredLoc, "restore-dir", "", "Restored location")
 	consistency.PersistentFlags().BoolVar(&recursive, "recursive", false, "Recursively check for row counts across dbs")
 	consistency.PersistentFlags().BoolVar(&paranoid, "paranoid", false, "Do paranoid checks on the DB")
 	consistency.PersistentFlags().IntVar(&threads, "threads", 2*runtime.NumCPU(), "Number of threads to do backup")

--- a/cmd/consistency/consistency.go
+++ b/cmd/consistency/consistency.go
@@ -14,9 +14,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var consistencySource string
-var consistencyRestore string
-var consistencyThreads int
+var source string
+var restoredLoc string
+var threads int
 var recursive bool
 
 // Work struct contains Source and Restore locations for checking consistency
@@ -33,18 +33,18 @@ var consistency = &cobra.Command{
 }
 
 func checkConsistency(args []string) (err error) {
-	if consistencySource == "" {
+	if source == "" {
 		return fmt.Errorf("--src was not set")
 	}
 
-	if consistencyRestore == "" {
+	if restoredLoc == "" {
 		return fmt.Errorf("--dest was not set")
 	}
 
 	if recursive {
-		return DoRecursiveConsistency(consistencySource, consistencyRestore, consistencyThreads)
+		return DoRecursiveConsistency(source, restoredLoc, threads)
 	}
-	return DoConsistency(consistencySource, consistencyRestore)
+	return DoConsistency(source, restoredLoc)
 }
 
 // DoRecursiveConsistency checks for consistency recursively
@@ -119,8 +119,8 @@ func DoConsistency(source, restore string) error {
 func init() {
 	cmd.Rocks.AddCommand(consistency)
 
-	consistency.PersistentFlags().StringVar(&consistencySource, "src", "", "Rocks store location")
-	consistency.PersistentFlags().StringVar(&consistencyRestore, "dest", "", "Restore location for Rocks store")
-	consistency.PersistentFlags().BoolVar(&recursive, "recursive", false, "Trying to check consistency between rocks store and and it's restore")
-	consistency.PersistentFlags().IntVar(&consistencyThreads, "threads", 2*runtime.NumCPU(), "Number of threads to do backup")
+	consistency.PersistentFlags().StringVar(&source, "src", "", "Rocks store location")
+	consistency.PersistentFlags().StringVar(&restoredLoc, "dest", "", "Restore location for Rocks store")
+	consistency.PersistentFlags().BoolVar(&recursive, "recursive", false, "Recursively check for row counts across dbs")
+	consistency.PersistentFlags().IntVar(&threads, "threads", 2*runtime.NumCPU(), "Number of threads to do backup")
 }

--- a/cmd/consistency/consistency_test.go
+++ b/cmd/consistency/consistency_test.go
@@ -38,6 +38,7 @@ func TestConsitency(t *testing.T) {
 
 	result := DoConsistency(dataDir, restoreDir, true)
 	assert.NoError(t, result.Err)
+	assert.True(t, result.IsConsistent())
 }
 
 func TestRecursiveConsistency(t *testing.T) {
@@ -70,18 +71,10 @@ func TestRecursiveConsistency(t *testing.T) {
 		testutils.WriteTestDB(t, filepath.Join(baseDataDir, relLocation))
 	}
 
-	// recursive backup + assert it
 	err = backup.DoRecursiveBackup(baseDataDir, baseBackupDir, 1)
 	assert.NoError(t, err)
-	for _, relLocation := range paths {
-		assert.True(t, testutils.Exists(filepath.Join(baseBackupDir, relLocation, cmd.LatestBackup)))
-	}
-
 	err = restore.DoRecursiveRestore(baseBackupDir, baseRestoreDir, baseRestoreDir, 5, true)
 	assert.NoError(t, err)
-	for _, relLocation := range paths {
-		assert.True(t, testutils.Exists(filepath.Join(baseRestoreDir, relLocation, cmd.Current)))
-	}
 
 	err = DoRecursiveConsistency(baseDataDir, baseRestoreDir, 5)
 	assert.NoError(t, err)

--- a/cmd/consistency/consistency_test.go
+++ b/cmd/consistency/consistency_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ind9/rocks/cmd"
@@ -35,8 +36,8 @@ func TestConsitency(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, testutils.Exists(filepath.Join(restoreDir, cmd.Current)))
 
-	err = DoConsistency(dataDir, restoreDir)
-	assert.NoError(t, err)
+	result := DoConsistency(dataDir, restoreDir, true)
+	assert.NoError(t, result.Err)
 }
 
 func TestRecursiveConsistency(t *testing.T) {
@@ -84,4 +85,45 @@ func TestRecursiveConsistency(t *testing.T) {
 
 	err = DoRecursiveConsistency(baseDataDir, baseRestoreDir, 5)
 	assert.NoError(t, err)
+}
+
+func TestConsitencyWithParanoidMode(t *testing.T) {
+	backupDir, err := ioutil.TempDir("", "ind9-rocks-backup")
+	assert.NoError(t, err)
+	defer os.RemoveAll(backupDir)
+	restoreDir, err := ioutil.TempDir("", "ind9-rocks-restore")
+	assert.NoError(t, err)
+	defer os.RemoveAll(restoreDir)
+	dataDir, err := ioutil.TempDir("", "ind9-rocks")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+
+	testutils.WriteTestDB(t, dataDir)
+
+	err = backup.DoBackup(dataDir, backupDir)
+	assert.NoError(t, err)
+	assert.True(t, testutils.Exists(filepath.Join(backupDir, cmd.LatestBackup)))
+
+	err = restore.DoRestore(backupDir, restoreDir, restoreDir, false)
+	assert.NoError(t, err)
+	assert.True(t, testutils.Exists(filepath.Join(restoreDir, cmd.Current)))
+
+	// Truncate one of the files on restoreDir
+	files, err := filepath.Glob(fmt.Sprintf("%s/*.sst", restoreDir))
+	assert.NoError(t, err)
+	err = os.Truncate(files[0], 1)
+	assert.NoError(t, err)
+
+	// bail out early
+	resultWithParanoid := DoConsistency(dataDir, restoreDir, true)
+	assert.Error(t, resultWithParanoid.Err)
+	assert.True(t, strings.HasPrefix(resultWithParanoid.Err.Error(), "Corruption: Sst file size mismatch"), "should be sst file size mismatch")
+	assert.Equal(t, int64(0), resultWithParanoid.SourceCount)
+	assert.Equal(t, int64(0), resultWithParanoid.RestoredCount)
+
+	// bail out only when reading through the entire db
+	resultWithoutParanoid := DoConsistency(dataDir, restoreDir, false)
+	assert.Error(t, resultWithoutParanoid.Err)
+	assert.Equal(t, int64(2), resultWithoutParanoid.SourceCount)
+	assert.Equal(t, int64(0), resultWithoutParanoid.RestoredCount)
 }


### PR DESCRIPTION
Introducing `--paranoid` flag in `rocks consistency` command to bail out early in case of datacorruption. 

Few other minor refactoring. 

Ref - https://github.com/facebook/rocksdb/wiki/Basic-Operations#checksums
@aayushKumarJarvis Please have a look at this. We can use this to catch the issues on the DB much early. 
